### PR TITLE
gh-49: Build add publish parent Docker image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+# Extend the base image for running a devcontainer within vscode.
+ARG DEBIAN_VERSION=bookworm
+FROM mcr.microsoft.com/vscode/devcontainers/base:$DEBIAN_VERSION
+
+# Install dependencies (compilers, openmpi, git, etc)
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -y --no-install-recommends \
+gfortran git wget cmake python3-pip m4 openmpi-bin openmpi-doc libopenmpi-dev
+RUN apt clean && rm -rf /var/lib/apt/lists/*
+
+# Create symlink to python3 as some tools expect a python executable which doesn't exist by default
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Allow MPI to oversubscribe
+ENV OMPI_MCA_rmaps_base_oversubscribe=true
+
+# Switch to the pre-existing vscode user to limit permissions
+USER vscode
+WORKDIR /home/vscode/
+
+# Install fortls to enable Fortran VSCode extension
+RUN python3 -m pip install fortls --break-system-packages
+
+# Build pfunit using custom script
+COPY scripts/build-pfunit.sh /home/vscode/build-pfunit.sh
+RUN /home/vscode/build-pfunit.sh -b -p /home/vscode/pfunit
+
+# Test pFUnit build
+RUN /home/vscode/build-pfunit.sh -t -p /home/vscode/pfunit
+
+# Store path to pFUnit installed directory for easy access later
+ENV PFUNIT_INSTALLED_PATH=/home/vscode/pfunit/build/installed

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+    "name": "fortran-unit-test",
+    "image": "ghcr.io/carpentries-incubator/fortran-unit-testing:main",
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-vscode.cpptools-extension-pack",
+          "ms-vscode.cpptools",
+          "bierner.markdown-checkbox",
+          "bierner.markdown-emoji",
+          "kejun.markdown-alert",
+          "bierner.markdown-preview-github-styles",
+          "fortran-lang.linter-gfortran",
+        ],
+        "commands": [
+          "workbench.action.terminal.new"
+        ],
+        "settings": {
+          "workbench.editorAssociations": {
+              "*.md": "vscode.markdown.preview.editor"
+          }
+        }
+      }
+    },
+    "remoteUser": "vscode",
+    "postCreateCommand": "code README.md"
+  }

--- a/.github/workflows/docker_build_parent_exercises_image.yaml
+++ b/.github/workflows/docker_build_parent_exercises_image.yaml
@@ -1,0 +1,64 @@
+# Based on https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+---
+name: "Build and publish parent docker image for the exercises"
+
+on:
+  # Allow manual execution for testing, hot-fixes, etc
+  workflow_dispatch:
+  # Build on pushes to main if relevant files have changed
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/docker_build_parent_exercises_image.yaml'
+      - '.devcontainer/Dockerfile'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push-parent-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Lowercase image name
+        run: |
+          IMAGE_NAME="$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+          echo "IMAGE_NAME=${IMAGE_NAME}" >> "${GITHUB_ENV}"
+
+      # Ensure there is enough space for building the large docker image
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          large-packages: false
+
+      - name: Build and push to ghcr
+        uses: aleskxyz/build-push@597b92355b8063b229b03ad0c2f7c1bdeb8f9ab4
+        with:
+          dockerfile_path: ./.devcontainer/Dockerfile
+          image_name: ${{ env.IMAGE_NAME }}
+          tags: |
+            latest
+            type=ref,event=branch
+          context: .
+          push_to_registry: true
+          registry_address: ${{ env.REGISTRY }}
+          registry_username: ${{ github.actor }}
+          registry_password: ${{ github.token }}


### PR DESCRIPTION
Adds the Dockerfile for the tests parent docker image as well as the workflow to build and publish it.